### PR TITLE
Look up book by remote_id when adding tag

### DIFF
--- a/fedireads/view_actions.py
+++ b/fedireads/view_actions.py
@@ -283,8 +283,9 @@ def tag(request):
     # field which doesn't validate
     name = request.POST.get('name')
     book_id = request.POST.get('book')
+    remote_id = 'https://%s/book/%s' % (DOMAIN, book_id)
 
-    outgoing.handle_tag(request.user, book_id, name)
+    outgoing.handle_tag(request.user, remote_id, name)
     return redirect('/book/%s' % book_id)
 
 


### PR DESCRIPTION
This is what downstream expects, I think this is the right level to convert. This fixes tag adding, which was previously failing because it couldn't find the book to tag