### PR TITLE
Run docker-compose flower in main container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM python:3
-ENV  PYTHONUNBUFFERED 1
+FROM python:3.9
+
+ENV PYTHONUNBUFFERED 1
+
 RUN mkdir /app
 RUN mkdir /app/static
 RUN mkdir /app/images
+
 WORKDIR /app
+
 COPY requirements.txt /app/
 RUN pip install -r requirements.txt
+
 COPY ./bookwyrm /app
 COPY ./celerywyrm /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,8 @@ services:
             - redis
         restart: on-failure
     flower:
-        image: mher/flower
+        build: .
+        command: flower --port=8888
         env_file: .env
         environment:
             - CELERY_BROKER_URL=${CELERY_BROKER}


### PR DESCRIPTION
# Description

This PR switches from using the dockerhub version of flower, to using the flower that is run within the main container. This ensures that the flower run in docker is always pinned to whatever is in requirements.txt

# How I tested

I tried running it, and it looked like it worked and I could see the celery worker. I haven't done much with bookwyrm yet so haven't got much further than that!
