### PR TITLE
A few small label-related accessibility fixes

### DIFF
--- a/bookwyrm/templates/book.html
+++ b/bookwyrm/templates/book.html
@@ -96,16 +96,16 @@
                 <div class="toggle-content hidden">
                     <div class="box">
                         <form name="edit-readthrough" action="/edit-readthrough" method="post">
-                        {% csrf_token %}
-                        <input type="hidden" name="id" value="{{ readthrough.id }}">
+                            {% csrf_token %}
+                            <input type="hidden" name="id" value="{{ readthrough.id }}">
                             <div class="field">
-                                <label class="label" for="start_date">
+                                <label class="label">
                                     Started reading
                                     <input type="date" name="start_date" class="input" id="id_start_date-{{ readthrough.id }}" value="{{ readthrough.start_date | date:"Y-m-d" }}">
                                 </label>
                             </div>
                             <div class="field">
-                                <label class="label" for="finish_date">
+                                <label class="label">
                                     Finished reading
                                     <input type="date" name="finish_date" class="input" id="id_finish_date-{{ readthrough.id }}" value="{{ readthrough.finish_date | date:"Y-m-d" }}">
                                 </label>

--- a/bookwyrm/templates/book.html
+++ b/bookwyrm/templates/book.html
@@ -150,11 +150,11 @@
             </div>
 
             <div class="block">
-                <h3>Tags</h3>
                 <form name="tag" action="/tag/" method="post">
+                    <label for="tags" class="is-3">Tags</label>
                     {% csrf_token %}
                     <input type="hidden" name="book" value="{{ book.id }}">
-                    <input class="input" type="text" name="name">
+                    <input id="tags" class="input" type="text" name="name">
                     <button class="button" type="submit">Add tag</button>
                 </form>
             </div>

--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -25,16 +25,16 @@
         <a class="navbar-item" href="/">
             <img class="image logo" src="/static/images/logo-small.png" alt="BookWyrm">
         </a>
-	<form class="navbar-item" action="/search/">
-	    <div class="field is-grouped">
-                <input class="input" type="text" name="q" placeholder="Search for a book or user" value="{{ query }}">
-		<button class="button" type="submit">
-		    <span class="icon icon-search">
-			<span class="is-sr-only">search</span>
-		    </span>
-		</button>
-	    </div>
-	</form>
+        <form class="navbar-item" action="/search/">
+            <div class="field is-grouped">
+                <input aria-label="Search for a book or user" id="search-input" class="input" type="text" name="q" placeholder="Search for a book or user" value="{{ query }}">
+                <button class="button" type="submit">
+                    <span class="icon icon-search">
+                    <span class="is-sr-only">search</span>
+                    </span>
+                </button>
+            </div>
+        </form>
 
         <label for="main-nav" role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="mainNav">
             <span aria-hidden="true"></span>

--- a/bookwyrm/templates/snippets/shelve_button.html
+++ b/bookwyrm/templates/snippets/shelve_button.html
@@ -71,7 +71,7 @@
                     {% csrf_token %}
                     <input type="hidden" name="book" value="{{ book.id }}">
                     <div class="field">
-                        <label class="label" for="start_date">
+                        <label class="label">
                             Started reading
                             <input type="date" name="start_date" class="input" id="start_id_start_date-{{ uuid }}" value="{% now "Y-m-d" %}">
                         </label>
@@ -114,13 +114,13 @@
                     <input type="hidden" name="book" value="{{ book.id }}">
                     <input type="hidden" name="id" value="{{ readthrough.id }}">
                     <div class="field">
-                        <label class="label" for="start_date">
+                        <label class="label">
                             Started reading
                             <input type="date" name="start_date" class="input" id="finish_id_start_date-{{ uuid }}" value="{{ readthrough.start_date | date:"Y-m-d" }}">
                         </label>
                     </div>
                     <div class="field">
-                        <label class="label" for="finish_date">
+                        <label class="label">
                             Finished reading
                             <input type="date" name="finish_date" class="input" id="id_finish_date-{{ uuid }}" value="{% now "Y-m-d" %}">
                         </label>


### PR DESCRIPTION
Fixes a few small things outlined in https://github.com/mouse-reeve/bookwyrm/issues/313:
- Book start modal & book edit page now read the "started reading" & "finished reading" label for the related date fields
- Book details page reads the label for tags input
- On site nav, adds a label to the search input