### PR TITLE
Fix navbar on mobile, make search an addon

### DIFF
--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -25,7 +25,7 @@
         <a class="navbar-item" href="/">
             <img class="image logo" src="/static/images/logo-small.png" alt="Home page">
         </a>
-        <form class="navbar-item column is-third-mobile" action="/search/">
+        <form class="navbar-item column" action="/search/">
             <div class="field has-addons">
                 <div class="control">
                     <input aria-label="Search for a book or user" id="search-input" class="input" type="text" name="q" placeholder="Search for a book or user" value="{{ query }}">

--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -25,14 +25,18 @@
         <a class="navbar-item" href="/">
             <img class="image logo" src="/static/images/logo-small.png" alt="Home page">
         </a>
-        <form class="navbar-item" action="/search/">
-            <div class="field is-grouped">
-                <input aria-label="Search for a book or user" id="search-input" class="input" type="text" name="q" placeholder="Search for a book or user" value="{{ query }}">
-                <button class="button" type="submit">
-                    <span class="icon icon-search">
-                        <span class="is-sr-only">search</span>
-                    </span>
-                </button>
+        <form class="navbar-item column is-third-mobile" action="/search/">
+            <div class="field has-addons">
+                <div class="control">
+                    <input aria-label="Search for a book or user" id="search-input" class="input" type="text" name="q" placeholder="Search for a book or user" value="{{ query }}">
+                </div>
+                <div class="control">
+                    <button class="button" type="submit">
+                        <span class="icon icon-search">
+                            <span class="is-sr-only">search</span>
+                        </span>
+                    </button>
+                </div>
             </div>
         </form>
 


### PR DESCRIPTION
This should fix #305, I think, just make the search box container a proper column that takes up a third of the space.

Also, in reading up on Bulma I found the has-addons option which is a nice touch, I think - if you prefer the previous way feel free to put it back :)