### PR TITLE
Replaces naive datetimes with aware ones

### DIFF
--- a/bookwyrm/forms.py
+++ b/bookwyrm/forms.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from django import forms
 from django.forms import ModelForm, PasswordInput, widgets
 from django.forms.widgets import Textarea
+from django.utils import timezone
 
 from bookwyrm import models
 
@@ -143,7 +144,7 @@ class ExpiryWidget(widgets.Select):
         else:
             return selected_string # "This will raise
 
-        return datetime.datetime.now() + interval
+        return timezone.now() + interval
 
 class CreateInviteForm(CustomForm):
     class Meta:

--- a/bookwyrm/migrations/0006_auto_20200221_1702_squashed_0064_merge_20201101_1913.py
+++ b/bookwyrm/migrations/0006_auto_20200221_1702_squashed_0064_merge_20201101_1913.py
@@ -3,7 +3,6 @@
 import bookwyrm.models.connector
 import bookwyrm.models.site
 import bookwyrm.utils.fields
-import datetime
 from django.conf import settings
 import django.contrib.postgres.operations
 import django.core.validators
@@ -37,7 +36,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='status',
             name='published_date',
-            field=models.DateTimeField(default=datetime.datetime.now),
+            field=models.DateTimeField(default=django.utils.timezone.now),
         ),
         migrations.CreateModel(
             name='Edition',
@@ -129,7 +128,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='book',
             name='last_sync_date',
-            field=models.DateTimeField(default=datetime.datetime.now),
+            field=models.DateTimeField(default=django.utils.timezone.now),
         ),
         migrations.AddField(
             model_name='book',

--- a/bookwyrm/models/import_job.py
+++ b/bookwyrm/models/import_job.py
@@ -132,14 +132,16 @@ class ImportItem(models.Model):
     def date_added(self):
         ''' when the book was added to this dataset '''
         if self.data['Date Added']:
-            return dateutil.parser.parse(self.data['Date Added'])
+            return timezone.make_aware(
+                dateutil.parser.parse(self.data['Date Added']))
         return None
 
     @property
     def date_read(self):
         ''' the date a book was completed '''
         if self.data['Date Read']:
-            return dateutil.parser.parse(self.data['Date Read'])
+            return timezone.make_aware(
+                dateutil.parser.parse(self.data['Date Read']))
         return None
 
     @property

--- a/bookwyrm/models/site.py
+++ b/bookwyrm/models/site.py
@@ -54,7 +54,7 @@ class SiteInvite(models.Model):
 
 def get_passowrd_reset_expiry():
     ''' give people a limited time to use the link '''
-    now = datetime.datetime.now()
+    now = timezone.now()
     return now + datetime.timedelta(days=1)
 
 

--- a/bookwyrm/status.py
+++ b/bookwyrm/status.py
@@ -1,5 +1,5 @@
 ''' Handle user activity '''
-from datetime import datetime
+from django.utils import timezone
 
 from bookwyrm import activitypub, books_manager, models
 from bookwyrm.sanitize_html import InputHtmlParser
@@ -8,7 +8,7 @@ from bookwyrm.sanitize_html import InputHtmlParser
 def delete_status(status):
     ''' replace the status with a tombstone '''
     status.deleted = True
-    status.deleted_date = datetime.now()
+    status.deleted_date = timezone.now()
     status.save()
 
 

--- a/bookwyrm/tests/connectors/test_self_connector.py
+++ b/bookwyrm/tests/connectors/test_self_connector.py
@@ -1,6 +1,7 @@
 ''' testing book data connectors '''
 import datetime
 from django.test import TestCase
+from django.utils import timezone
 
 from bookwyrm import models
 from bookwyrm.connectors.self_connector import Connector
@@ -27,7 +28,7 @@ class SelfConnector(TestCase):
         self.edition = models.Edition.objects.create(
             title='Edition of Example Work',
             author_text='Anonymous',
-            published_date=datetime.datetime(1980, 5, 10),
+            published_date=datetime.datetime(1980, 5, 10, tzinfo=timezone.utc),
             parent_work=self.work,
         )
         models.Edition.objects.create(

--- a/bookwyrm/tests/models/test_import_model.py
+++ b/bookwyrm/tests/models/test_import_model.py
@@ -1,5 +1,6 @@
 ''' testing models '''
 import datetime
+from django.utils import timezone
 from django.test import TestCase
 
 from bookwyrm import models
@@ -77,29 +78,29 @@ class ImportJob(TestCase):
 
     def test_date_added(self):
         ''' converts to the local shelf typology '''
-        expected = datetime.datetime(2019, 4, 9, 0, 0)
+        expected = datetime.datetime(2019, 4, 9, 0, 0, tzinfo=timezone.utc)
         item = models.ImportItem.objects.get(index=1)
         self.assertEqual(item.date_added, expected)
 
 
     def test_date_read(self):
         ''' converts to the local shelf typology '''
-        expected = datetime.datetime(2019, 4, 12, 0, 0)
+        expected = datetime.datetime(2019, 4, 12, 0, 0, tzinfo=timezone.utc)
         item = models.ImportItem.objects.get(index=2)
         self.assertEqual(item.date_read, expected)
 
 
     def test_currently_reading_reads(self):
         expected = [models.ReadThrough(
-            start_date=datetime.datetime(2019, 4, 9, 0, 0))]
+            start_date=datetime.datetime(2019, 4, 9, 0, 0, tzinfo=timezone.utc))]
         actual = models.ImportItem.objects.get(index=1)
         self.assertEqual(actual.reads[0].start_date, expected[0].start_date)
         self.assertEqual(actual.reads[0].finish_date, expected[0].finish_date)
 
     def test_read_reads(self):
         actual = models.ImportItem.objects.get(index=2)
-        self.assertEqual(actual.reads[0].start_date, datetime.datetime(2019, 4, 9, 0, 0))
-        self.assertEqual(actual.reads[0].finish_date, datetime.datetime(2019, 4, 12, 0, 0))
+        self.assertEqual(actual.reads[0].start_date, datetime.datetime(2019, 4, 9, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(actual.reads[0].finish_date, datetime.datetime(2019, 4, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_unread_reads(self):
         expected = []

--- a/bookwyrm/wellknown.py
+++ b/bookwyrm/wellknown.py
@@ -1,10 +1,9 @@
 ''' responds to various requests to /.well-know '''
 
-from datetime import datetime
-
 from dateutil.relativedelta import relativedelta
 from django.http import HttpResponseNotFound
 from django.http import JsonResponse
+from django.utils import timezone
 
 from bookwyrm import models
 from bookwyrm.settings import DOMAIN
@@ -60,13 +59,13 @@ def nodeinfo(request):
     status_count = models.Status.objects.filter(user__local=True).count()
     user_count = models.User.objects.filter(local=True).count()
 
-    month_ago = datetime.now() - relativedelta(months=1)
+    month_ago = timezone.now() - relativedelta(months=1)
     last_month_count = models.User.objects.filter(
         local=True,
         last_active_date__gt=month_ago
     ).count()
 
-    six_months_ago = datetime.now() - relativedelta(months=6)
+    six_months_ago = timezone.now() - relativedelta(months=6)
     six_month_count = models.User.objects.filter(
         local=True,
         last_active_date__gt=six_months_ago


### PR DESCRIPTION
This replaces various timezone-naive datetimes with timezone-aware ones, using `django.util.timezone`. This should fix everything that's covered in tests, but there may be other usages that don't have test coverage, although I searched through the codebase for keywords and didn't find any.