### PR TITLE
[WIP] Cancel follow requests

### DIFF
--- a/bookwyrm/outgoing.py
+++ b/bookwyrm/outgoing.py
@@ -114,6 +114,15 @@ def handle_reject(follow_request):
     broadcast(to_follow, activity, privacy='direct', direct_recipients=[user])
 
 
+def handle_cancel(follow_request):
+    ''' a local user cancels a follow request to another user '''
+    user = follow_request.user_subject
+    requested = follow_request.user_object
+    activity = follow_request.to_undo_activity(user)
+    follow_request.delete()
+    broadcast(user, activity, privacy='direct', direct_recipients=[requested])
+
+
 def handle_shelve(user, book, shelf):
     ''' a local user is getting a book put on their shelf '''
     # update the database

--- a/bookwyrm/outgoing.py
+++ b/bookwyrm/outgoing.py
@@ -82,7 +82,7 @@ def handle_follow(user, to_follow):
 
 
 def handle_unfollow(user, to_unfollow):
-    ''' someone local wants to follow someone '''
+    ''' someone local wants to unfollow someone '''
     relationship = models.UserFollows.objects.get(
         user_subject=user,
         user_object=to_unfollow

--- a/bookwyrm/templates/snippets/follow_button.html
+++ b/bookwyrm/templates/snippets/follow_button.html
@@ -1,9 +1,11 @@
 {% if request.user == user or not request.user.is_authenticated %}
 {% elif request.user in user.follower_requests.all %}
 
-<div>
-Follow request already sent.
-</div>
+<form action="/cancel-follow-request/" method="POST" onsubmit="interact(event)" class="follow-{{ user.id }}" data-id="follow-{{ user.id }}">
+    {% csrf_token %}
+    <input type="hidden" name="user" value="{{ user.username }}">
+    <button class="button is-small is-danger is-light" type="submit">Cancel request</button>
+</form>
 
 {% else %}
 

--- a/bookwyrm/urls.py
+++ b/bookwyrm/urls.py
@@ -138,6 +138,7 @@ urlpatterns = [
     re_path(r'^unfollow/?$', actions.unfollow),
     re_path(r'^accept-follow-request/?$', actions.accept_follow_request),
     re_path(r'^delete-follow-request/?$', actions.delete_follow_request),
+    re_path(r'^cancel-follow-request/?$', actions.cancel_follow_request),
 
     re_path(r'^clear-notifications/?$', actions.clear_notifications),
 

--- a/bookwyrm/view_actions.py
+++ b/bookwyrm/view_actions.py
@@ -754,8 +754,7 @@ def cancel_follow_request(request):
         return HttpResponseBadRequest()
 
     outgoing.handle_cancel(follow_request)
-    user_slug = requested.localname if requested.localname \
-        else requested.username
+    user_slug = requested.localname or requested.username
     return redirect('/user/%s' % user_slug)
 
 

--- a/bookwyrm/view_actions.py
+++ b/bookwyrm/view_actions.py
@@ -737,6 +737,30 @@ def delete_follow_request(request):
 
 @login_required
 @require_POST
+def cancel_follow_request(request):
+    ''' cancel a follow request from the requester's side '''
+    username = request.POST['user']
+    try:
+        requested = get_user_from_username(username)
+    except models.User.DoesNotExist:
+        return HttpResponseBadRequest()
+
+    try:
+        follow_request = models.UserFollowRequest.objects.get(
+            user_subject=request.user,
+            user_object=requested
+        )
+    except models.UserFollowRequest.DoesNotExist:
+        return HttpResponseBadRequest()
+
+    outgoing.handle_cancel(follow_request)
+    user_slug = requested.localname if requested.localname \
+        else requested.username
+    return redirect('/user/%s' % user_slug)
+
+
+@login_required
+@require_POST
 def import_data(request):
     ''' ingest a goodreads csv '''
     form = forms.ImportForm(request.POST, request.FILES)


### PR DESCRIPTION
Ok, I'm going to stop trying to pretend I should know all this - having never worked with Python nor ActivityPub before - and just publish a draft PR 😅 If someone has the det to help, that would be much appreciated, otherwise, I'll leave this here while I go read a bunch of docs 📖

So, here's what I've got so far. I seem to be able to cancel requests locally, but...

1. ...I'm not really sure about the incoming thing, nor how to test it. There is a `handle_unfollow` already, but it doesn't appear to be called (because I'm testing locally), so I don't know if it would work and my brain stopped for a bit. 🙅🧠
2. ...after I send a follow request, the button goes to `Unfollow` and requires a refresh to go to `Cancel request`. I'm assuming this is because `user.follower_requests.all` isn't updated, but I don't know how Django works yet, so.. To the docs!📚

Also, does 5e0aa1b  make sense, or no? Seemed to work in a repl, but I, again, don't know a lot about Python, so.. 🤷

Closes #282 