### PR TITLE
Create a ActivitypubResponse class and use it in the views

### DIFF
--- a/bookwyrm/activitypub/__init__.py
+++ b/bookwyrm/activitypub/__init__.py
@@ -11,6 +11,7 @@ from .note import Tombstone
 from .interaction import Boost, Like
 from .ordered_collection import OrderedCollection, OrderedCollectionPage
 from .person import Person, PublicKey
+from .response import ActivitypubResponse
 from .book import Edition, Work, Author
 from .verbs import Create, Delete, Undo, Update
 from .verbs import Follow, Accept, Reject

--- a/bookwyrm/activitypub/response.py
+++ b/bookwyrm/activitypub/response.py
@@ -1,0 +1,18 @@
+from django.http import JsonResponse
+
+from .base_activity import ActivityEncoder
+
+class ActivitypubResponse(JsonResponse):
+    """
+    A class to be used in any place that's serializing responses for
+    Activitypub enabled clients. Uses JsonResponse under the hood, but already
+    configures some stuff beforehand. Made to be a drop-in replacement of
+    JsonResponse.
+    """
+    def __init__(self, data, encoder=ActivityEncoder, safe=True,
+                 json_dumps_params=None, **kwargs):
+
+        if 'content_type' not in kwargs:
+            kwargs['content_type'] = 'application/activity+json'
+
+        super().__init__(data, encoder, safe, json_dumps_params, **kwargs)


### PR DESCRIPTION
This is linked to #429. This does not change the responses themselves, but changes the content-type of the activitypub-linked responses by introducing an ActivitypubResponse class, which mimics JsonResponse, but uses ActivityEncoder and sets the content-type accordingly.