### PR TITLE
Add BookWyrm user-agent to http requests

### DIFF
--- a/bookwyrm/broadcast.py
+++ b/bookwyrm/broadcast.py
@@ -3,7 +3,7 @@ import json
 from django.utils.http import http_date
 import requests
 
-from bookwyrm import models
+from bookwyrm import models, settings
 from bookwyrm.activitypub import ActivityEncoder
 from bookwyrm.tasks import app
 from bookwyrm.signatures import make_signature, make_digest
@@ -79,6 +79,7 @@ def sign_and_send(sender, data, destination):
             'Digest': digest,
             'Signature': make_signature(sender, destination, now, digest),
             'Content-Type': 'application/activity+json; charset=utf-8',
+            'User-Agent': settings.USER_AGENT,
         },
     )
     if not response.ok:

--- a/bookwyrm/connectors/abstract_connector.py
+++ b/bookwyrm/connectors/abstract_connector.py
@@ -8,7 +8,7 @@ import requests
 from requests import HTTPError
 from requests.exceptions import SSLError
 
-from bookwyrm import activitypub, models
+from bookwyrm import activitypub, models, settings
 
 
 class ConnectorException(HTTPError):
@@ -42,6 +42,7 @@ class AbstractMinimalConnector(ABC):
             '%s%s' % (self.search_url, query),
             headers={
                 'Accept': 'application/json; charset=utf-8',
+                'User-Agent': settings.USER_AGENT,
             },
         )
         if not resp.ok:
@@ -196,6 +197,7 @@ def get_data(url):
             url,
             headers={
                 'Accept': 'application/json; charset=utf-8',
+                'User-Agent': settings.USER_AGENT,
             },
         )
     except RequestError:
@@ -213,7 +215,12 @@ def get_data(url):
 def get_image(url):
     ''' wrapper for requesting an image '''
     try:
-        resp = requests.get(url)
+        resp = requests.get(
+            url,
+            headers={
+                'User-Agent': settings.USER_AGENT,
+            },
+        )
     except (RequestError, SSLError):
         return None
     if not resp.ok:

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -3,6 +3,8 @@ import os
 
 from environs import Env
 
+import requests
+
 env = Env()
 DOMAIN = env('DOMAIN')
 
@@ -150,3 +152,7 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, env('STATIC_ROOT', 'static'))
 MEDIA_URL = '/images/'
 MEDIA_ROOT = os.path.join(BASE_DIR, env('MEDIA_ROOT', 'images'))
+
+USER_AGENT = "%s (BookWyrm/%s; +https://%s/)" % (requests.utils.default_user_agent(),
+        "0.1", # TODO: change 0.1 into actual version
+        DOMAIN)


### PR DESCRIPTION
This adds user-agent to all request calls currently done by BookWyrm and is also linked to #429.
For the user-agent, I followed the same idea as does [Mastodon](https://github.com/tootsuite/mastodon/blob/master/lib/mastodon/version.rb#L57), in the form of `python-requests/2.22.0 (BookWyrm/0.1; +https://localhost:1333/)`, containing the default user agent from the requests lib, then followed by a bookwyrm specifier and the domain. Another option would be use the style of pleroma `Pleroma 2.2.0; https://localhost:1333 <admin@email.com>` or PeerTube `PeerTube/2.4.0 (+https://localhost:1333)`.