### PR TITLE
Search tweaks

### DIFF
--- a/bookwyrm/connectors/self_connector.py
+++ b/bookwyrm/connectors/self_connector.py
@@ -23,6 +23,7 @@ class Connector(AbstractConnector):
             search_results.append(self.format_search_result(result))
             if len(search_results) >= 10:
                 break
+        search_results.sort(key=lambda r: r.confidence, reverse=True)
         return search_results
 
 
@@ -75,10 +76,10 @@ def search_identifiers(query):
 
 def search_title_author(query, min_confidence):
     ''' searches for title and author '''
-    print('DON"T BOTHER')
     vector = SearchVector('title', weight='A') +\
         SearchVector('subtitle', weight='B') +\
-        SearchVector('authors__name', weight='C')
+        SearchVector('authors__name', weight='C') +\
+        SearchVector('series', weight='D')
 
     results = models.Edition.objects.annotate(
         search=vector

--- a/bookwyrm/connectors/self_connector.py
+++ b/bookwyrm/connectors/self_connector.py
@@ -36,7 +36,7 @@ class Connector(AbstractConnector):
                     or results
 
         search_results = []
-        for book in results[:10]:
+        for book in set(results[:10]):
             search_results.append(
                 self.format_search_result(book)
             )

--- a/bookwyrm/tests/connectors/test_self_connector.py
+++ b/bookwyrm/tests/connectors/test_self_connector.py
@@ -48,6 +48,7 @@ class SelfConnector(TestCase):
         edition = models.Edition.objects.create(
             title='Edition of Example Work',
             published_date=datetime.datetime(1980, 5, 10, tzinfo=timezone.utc),
+            parent_work=models.Work.objects.create(title='')
         )
         # author text is rank C
         edition.authors.add(author)
@@ -55,18 +56,21 @@ class SelfConnector(TestCase):
         # series is rank D
         models.Edition.objects.create(
             title='Another Edition',
-            series='Anonymous'
+            series='Anonymous',
+            parent_work=models.Work.objects.create(title='')
         )
         # subtitle is rank B
         models.Edition.objects.create(
             title='More Editions',
             subtitle='The Anonymous Edition',
+            parent_work=models.Work.objects.create(title='')
         )
         # title is rank A
         models.Edition.objects.create(title='Anonymous')
         # doesn't rank in this search
         edition = models.Edition.objects.create(
             title='An Edition',
+            parent_work=models.Work.objects.create(title='')
         )
 
         results = self.connector.search('Anonymous')

--- a/bookwyrm/tests/connectors/test_self_connector.py
+++ b/bookwyrm/tests/connectors/test_self_connector.py
@@ -9,7 +9,9 @@ from bookwyrm.settings import DOMAIN
 
 
 class SelfConnector(TestCase):
+    ''' just uses local data '''
     def setUp(self):
+        ''' creating the connector '''
         models.Connector.objects.create(
             identifier=DOMAIN,
             name='Local',
@@ -22,58 +24,74 @@ class SelfConnector(TestCase):
             priority=1,
         )
         self.connector = Connector(DOMAIN)
-        self.work = models.Work.objects.create(
-            title='Example Work',
-        )
-        author = models.Author.objects.create(name='Anonymous')
-        self.edition = models.Edition.objects.create(
-            title='Edition of Example Work',
-            published_date=datetime.datetime(1980, 5, 10, tzinfo=timezone.utc),
-            parent_work=self.work,
-        )
-        self.edition.authors.add(author)
-        models.Edition.objects.create(
-            title='Another Edition',
-            parent_work=self.work,
-            series='Anonymous'
-        )
-        models.Edition.objects.create(
-            title='More Editions',
-            subtitle='The Anonymous Edition',
-            parent_work=self.work,
-        )
-
-        edition = models.Edition.objects.create(
-            title='An Edition',
-            parent_work=self.work
-        )
-        edition.authors.add(models.Author.objects.create(name='Fish'))
 
 
     def test_format_search_result(self):
+        ''' create a SearchResult '''
+        author = models.Author.objects.create(name='Anonymous')
+        edition = models.Edition.objects.create(
+            title='Edition of Example Work',
+            published_date=datetime.datetime(1980, 5, 10, tzinfo=timezone.utc),
+        )
+        edition.authors.add(author)
         result = self.connector.search('Edition of Example')[0]
         self.assertEqual(result.title, 'Edition of Example Work')
-        self.assertEqual(result.key, self.edition.remote_id)
+        self.assertEqual(result.key, edition.remote_id)
         self.assertEqual(result.author, 'Anonymous')
         self.assertEqual(result.year, 1980)
+        self.assertEqual(result.connector, self.connector)
 
 
     def test_search_rank(self):
+        ''' prioritize certain results '''
+        author = models.Author.objects.create(name='Anonymous')
+        edition = models.Edition.objects.create(
+            title='Edition of Example Work',
+            published_date=datetime.datetime(1980, 5, 10, tzinfo=timezone.utc),
+        )
+        # author text is rank C
+        edition.authors.add(author)
+
+        # series is rank D
+        models.Edition.objects.create(
+            title='Another Edition',
+            series='Anonymous'
+        )
+        # subtitle is rank B
+        models.Edition.objects.create(
+            title='More Editions',
+            subtitle='The Anonymous Edition',
+        )
+        # title is rank A
+        models.Edition.objects.create(title='Anonymous')
+        # doesn't rank in this search
+        edition = models.Edition.objects.create(
+            title='An Edition',
+        )
+
         results = self.connector.search('Anonymous')
-        self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].title, 'More Editions')
-        self.assertEqual(results[1].title, 'Edition of Example Work')
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0].title, 'Anonymous')
+        self.assertEqual(results[1].title, 'More Editions')
+        self.assertEqual(results[2].title, 'Edition of Example Work')
 
 
     def test_search_default_filter(self):
         ''' it should get rid of duplicate editions for the same work '''
-        self.work.default_edition = self.edition
-        self.work.save()
+        work = models.Work.objects.create(title='Work Title')
+        models.Edition.objects.create(
+            title='Edition 1 Title', parent_work=work)
+        edition_2 = models.Edition.objects.create(
+            title='Edition 2 Title', parent_work=work)
+        edition_3 = models.Edition.objects.create(
+            title='Fish', parent_work=work)
+        work.default_edition = edition_2
+        work.save()
 
-        results = self.connector.search('Anonymous')
+        results = self.connector.search('Edition Title')
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].title, 'Edition of Example Work')
+        self.assertEqual(results[0].key, edition_2.remote_id)
 
         results = self.connector.search('Fish')
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].title, 'An Edition')
+        self.assertEqual(results[0].key, edition_3.remote_id)


### PR DESCRIPTION
- uses the best match edition when multiple editions of the same work show up in search
- separates search on unique identifiers (like isbn) for best match searches (like title and author)
- removes distracting search fields (like description)
- properly deduplicates results

works on #446 