### PR TITLE
Use user-agent to determine whether to show pure representation

### DIFF
--- a/bookwyrm/tests/test_views.py
+++ b/bookwyrm/tests/test_views.py
@@ -10,7 +10,7 @@ from django.test.client import RequestFactory
 
 from bookwyrm import models, views
 from bookwyrm.connectors import abstract_connector
-from bookwyrm.settings import DOMAIN
+from bookwyrm.settings import DOMAIN, USER_AGENT
 
 
 # pylint: disable=too-many-public-methods
@@ -539,3 +539,16 @@ class Views(TestCase):
                 request, self.local_user.username, shelf.identifier)
         self.assertIsInstance(result, JsonResponse)
         self.assertEqual(result.status_code, 200)
+
+
+    def test_is_bookwyrm_request(self):
+        ''' tests the function that checks if a request came from a bookwyrm instance '''
+        request = self.factory.get('', {'q': 'Test Book'})
+        self.assertFalse(views.is_bookworm_request(request))
+
+        request = self.factory.get('', {'q': 'Test Book'},
+                HTTP_USER_AGENT="http.rb/4.4.1 (Mastodon/3.3.0; +https://mastodon.social/)")
+        self.assertFalse(views.is_bookworm_request(request))
+
+        request = self.factory.get('', {'q': 'Test Book'}, HTTP_USER_AGENT=USER_AGENT)
+        self.assertTrue(views.is_bookworm_request(request))

--- a/bookwyrm/utils/regex.py
+++ b/bookwyrm/utils/regex.py
@@ -6,3 +6,5 @@ strict_localname = r'@[a-zA-Z_\-\.0-9]+'
 username = r'%s(@%s)?' % (localname, domain)
 strict_username = r'%s(@%s)?' % (strict_localname, domain)
 full_username = r'%s@%s' % (localname, domain)
+# should match (BookWyrm/1.0.0; or (BookWyrm/99.1.2;
+bookwyrm_user_agent = r'\(BookWyrm/[0-9]+\.[0-9]+\.[0-9]+;'

--- a/bookwyrm/views.py
+++ b/bookwyrm/views.py
@@ -42,6 +42,13 @@ def is_api_request(request):
     return 'json' in request.headers.get('Accept') or \
             request.path[-5:] == '.json'
 
+def is_bookworm_request(request):
+    ''' check if the request is coming from another bookworm instance '''
+    user_agent = request.headers.get('User-Agent')
+    if user_agent is None or re.search(regex.bookwyrm_user_agent, user_agent) is None:
+        return False
+
+    return True
 
 def server_error_page(request):
     ''' 500 errors '''
@@ -505,7 +512,7 @@ def status_page(request, username, status_id):
         return HttpResponseNotFound()
 
     if is_api_request(request):
-        return ActivitypubResponse(status.to_activity())
+        return ActivitypubResponse(status.to_activity(pure=not is_bookworm_request(request)))
 
     data = {
         'title': 'Status by %s' % user.username,


### PR DESCRIPTION
Together with #434 and #435, this fixes #429. Use the user-agent to determine if the call is coming from a BookWyrm instance or not. If it's not, give a pure activitypub representation for the status. Otherwise give a BookWyrm one, to allow for a complete integration between instances.