### PR TITLE
Reverse shelf listing

### DIFF
--- a/bookwyrm/templates/snippets/shelf.html
+++ b/bookwyrm/templates/snippets/shelf.html
@@ -34,7 +34,7 @@
     </th>
     {% endif %}
 </tr>
-{% for book in books %}
+{% for book in books.reverse %}
 <tr class="book-preview">
     <td>
         {% include 'snippets/book_cover.html' with book=book size="small" %}


### PR DESCRIPTION
This reverses the default sort of the books on the shelf view. I think it makes sense to have the most recently-added books at the top of the page, rather than at the bottom.

Let me know if there's a different way that would be better to implement this! :)