### PR TITLE
Fix error in migrations

### DIFF
--- a/bookwyrm/migrations/0035_edition_edition_rank.py
+++ b/bookwyrm/migrations/0035_edition_edition_rank.py
@@ -8,7 +8,6 @@ def set_rank(app_registry, schema_editor):
     db_alias = schema_editor.connection.alias
     books = app_registry.get_model('bookwyrm', 'Edition')
     for book in books.objects.using(db_alias):
-        book.edition_rank = book.get_rank
         book.save()
 
 class Migration(migrations.Migration):

--- a/bookwyrm/models/book.py
+++ b/bookwyrm/models/book.py
@@ -178,7 +178,6 @@ class Edition(Book):
     activity_serializer = activitypub.Edition
     name_field = 'title'
 
-    @property
     def get_rank(self):
         ''' calculate how complete the data is on this edition '''
         if self.parent_work and self.parent_work.default_edition == self:
@@ -204,7 +203,7 @@ class Edition(Book):
             self.isbn_13 = isbn_10_to_13(self.isbn_10)
 
         # set rank
-        self.edition_rank = self.get_rank
+        self.edition_rank = self.get_rank()
 
         return super().save(*args, **kwargs)
 


### PR DESCRIPTION
I was getting the following error when running 0035:
```
  Applying bookwyrm.0035_edition_edition_rank...Traceback (most recent call last):
  File "/app/manage.py", line 18, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 328, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 369, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/base.py", line 83, in wrapped
    res = handle_func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/commands/migrate.py", line 231, in handle
    post_migrate_state = executor.migrate(
  File "/usr/local/lib/python3.9/site-packages/django/db/migrations/executor.py", line 117, in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/usr/local/lib/python3.9/site-packages/django/db/migrations/executor.py", line 147, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/usr/local/lib/python3.9/site-packages/django/db/migrations/executor.py", line 245, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/usr/local/lib/python3.9/site-packages/django/db/migrations/migration.py", line 124, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/usr/local/lib/python3.9/site-packages/django/db/migrations/operations/special.py", line 190, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "/app/bookwyrm/migrations/0035_edition_edition_rank.py", line 11, in set_rank
    book.edition_rank = book.get_rank
AttributeError: 'Edition' object has no attribute 'get_rank'
```

I started down the road of trying to figure out _why_ it couldn't find the attribute in the migration, because by all rights it seems like it should, but then I realized that if I'm reading it right, `Edition.save()` also does `self.edition_rank = self.get_rank`, so I don't think we need to do it in the migration after all.

While I was in there, I also de-property-ified `get_rank()`, since it seemed to be named and behaving more like a regular function. If you'd rather leave it as-is, feel free to revert that commit :)