### PR TITLE
Make login form wrap nicely on mobile

### DIFF
--- a/bookwyrm/templates/layout.html
+++ b/bookwyrm/templates/layout.html
@@ -127,17 +127,19 @@
                     <div class="column">
                         <form name="login" method="post" action="/user-login">
                             {% csrf_token %}
-                            <div class="field is-grouped">
-                                <div class="control">
+                            <div class="columns is-variable is-1">
+                                <div class="column">
                                     <label class="is-sr-only" for="id_localname">Username:</label>
                                     <input type="text" name="localname" maxlength="150" class="input" required="" id="id_localname" placeholder="username">
                                 </div>
-                                <div class="control">
+                                <div class="column">
                                     <label class="is-sr-only" for="id_password">Username:</label>
                                     <input type="password" name="password" maxlength="128" class="input" required="" id="id_password" placeholder="password">
                                     <p class="help"><a href="/password-reset">Forgot your password?</a></p>
                                 </div>
-                                <button class="button is-primary" type="submit">Log in</button>
+                                <div class="column is-narrow">
+                                    <button class="button is-primary" type="submit">Log in</button>
+                                </div>
                             </div>
                         </form>
                     </div>


### PR DESCRIPTION
Fix for #518. Open to feedback here, changing a form to columns from a grouped form item isn't my favorite, but I think it's okay, and it gets us better mobile behavior for free, which is the goal.