### PR TITLE
Add order for shelf books to satisfy warning

### DIFF
--- a/bookwyrm/models/base_model.py
+++ b/bookwyrm/models/base_model.py
@@ -225,6 +225,9 @@ class OrderedCollectionPageMixin(ActivitypubMixin):
     def to_ordered_collection(self, queryset, \
             remote_id=None, page=False, **kwargs):
         ''' an ordered collection of whatevers '''
+        if not queryset.ordered:
+            raise RuntimeError('queryset must be ordered')
+
         remote_id = remote_id or self.remote_id
         if page:
             return to_ordered_collection_page(
@@ -281,6 +284,4 @@ class OrderedCollectionMixin(OrderedCollectionPageMixin):
 
     def to_activity(self, **kwargs):
         ''' an ordered collection of the specified model queryset  '''
-        if not self.collection_queryset.ordered:
-            raise RuntimeError('collection_queryset must be ordered')
         return self.to_ordered_collection(self.collection_queryset, **kwargs)

--- a/bookwyrm/models/base_model.py
+++ b/bookwyrm/models/base_model.py
@@ -281,4 +281,6 @@ class OrderedCollectionMixin(OrderedCollectionPageMixin):
 
     def to_activity(self, **kwargs):
         ''' an ordered collection of the specified model queryset  '''
+        if not self.collection_queryset.ordered:
+            raise RuntimeError('collection_queryset must be ordered')
         return self.to_ordered_collection(self.collection_queryset, **kwargs)

--- a/bookwyrm/models/shelf.py
+++ b/bookwyrm/models/shelf.py
@@ -39,7 +39,7 @@ class Shelf(OrderedCollectionMixin, BookWyrmModel):
     @property
     def collection_queryset(self):
         ''' list of books for this shelf, overrides OrderedCollectionMixin  '''
-        return self.books.all()
+        return self.books.all().order_by('shelfbook')
 
     def get_remote_id(self):
         ''' shelf identifier instead of id '''
@@ -90,3 +90,4 @@ class ShelfBook(ActivitypubMixin, BookWyrmModel):
         ''' an opinionated constraint!
             you can't put a book on shelf twice '''
         unique_together = ('book', 'shelf')
+        ordering = ('-created_date',)


### PR DESCRIPTION
I decided to hunt down the "collection_queryset must be ordered" errors in the test suite, and it ended up being caused by `Shelf.collection_queryset()` not being ordered (it was just `self.books.all()`).

I think I managed to make it sort by order they were added to the shelf (aka creation date of the ShelfBook), but I haven't actually tested that. I should add some tests to make sure.

Also I added a RuntimeError if a `collection_queryset()` is not ordered, which now that I'm writing this I realize would probably be better placed directly in `to_ordered_collection()` maybe? Or, may not be worth having as an error at all.