### PR TITLE
Fix migration for if db has multiple empty emails

### DIFF
--- a/bookwyrm/migrations/0037_auto_20210118_1954.py
+++ b/bookwyrm/migrations/0037_auto_20210118_1954.py
@@ -2,6 +2,15 @@
 
 from django.db import migrations, models
 
+def empty_to_null(apps, schema_editor):
+    User = apps.get_model("bookwyrm", "User")
+    db_alias = schema_editor.connection.alias
+    User.objects.using(db_alias).filter(email="").update(email=None)
+
+def null_to_empty(apps, schema_editor):
+    User = apps.get_model("bookwyrm", "User")
+    db_alias = schema_editor.connection.alias
+    User.objects.using(db_alias).filter(email=None).update(email="")
 
 class Migration(migrations.Migration):
 
@@ -14,6 +23,12 @@ class Migration(migrations.Migration):
             name='shelfbook',
             options={'ordering': ('-created_date',)},
         ),
+        migrations.AlterField(
+            model_name='user',
+            name='email',
+            field=models.EmailField(max_length=254, null=True),
+        ),
+        migrations.RunPython(empty_to_null, null_to_empty),
         migrations.AlterField(
             model_name='user',
             name='email',


### PR DESCRIPTION
If the database has multiple users with an empty email column, this
migration will fail because multiple empty strings break the unique
constraint.

A fresh database won't have this problem because it won't have any
legacy users with empty strings instead of NULL, but for existing
databases we need to convert the empty strings to NULL so they don't run
awry of the unique constraint.