### PR TITLE
Proof of concept adding `black` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-.PHONY: itblack
-
-itblack:
-	docker-compose run --rm web black celerywyrm
-	docker-compose run --rm web black bookwyrm

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: itblack
+
+itblack:
+	docker-compose run --rm web black celerywyrm
+	docker-compose run --rm web black bookwyrm

--- a/bw-dev
+++ b/bw-dev
@@ -35,6 +35,10 @@ function initdb {
     execweb python manage.py initdb
 }
 
+function makeitblack {
+    runweb black celerywyrm bookwyrm
+}
+
 CMD=$1
 shift
 
@@ -96,7 +100,10 @@ case "$CMD" in
     clean)
         clean
         ;;
+    black)
+        makeitblack
+        ;;
     *)
-        echo "Unrecognised command. Try: build, clean, up, initdb, resetdb, makemigrations, migrate, bash, shell, dbshell, restart_celery, test, pytest, test_report"
+        echo "Unrecognised command. Try: build, clean, up, initdb, resetdb, makemigrations, migrate, bash, shell, dbshell, restart_celery, test, pytest, test_report, black"
         ;;
 esac

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 celery==4.4.2
-coverage==5.1
 Django==3.0.7
 django-model-utils==4.0.0
 environs==7.2.0
@@ -8,11 +7,15 @@ Markdown==3.3.3
 Pillow>=7.1.0
 psycopg2==2.8.4
 pycryptodome==3.9.4
-pytest-django==4.1.0
-pytest==6.1.2
-pytest-cov==2.10.1
 python-dateutil==2.8.1
 redis==3.4.1
 requests==2.22.0
 responses==0.10.14
 django-rename-app==0.1.2
+
+# Dev
+black==20.8b1
+coverage==5.1
+pytest-django==4.1.0
+pytest==6.1.2
+pytest-cov==2.10.1


### PR DESCRIPTION
This is more of a proof of concept of installing a runnable version of the `black` auto-formatter -- I've found this tool very useful in my work projects to support a generally-agreed-upon python style. The first time you run it, it makes a lot of changes, but then it's less dramatic as time goes on. There are plugins for IDEs such as VSCode that run this command every time you save a file, which allows you to just not think about some standard formatting tradeoffs.

You can see the changes this would apply by checking out this branch and running `make itblack`.

Take it or leave it w/r/t actually applying this to the project but thought you might be interested!

Ref: 

- https://github.com/psf/black
- https://github.com/psf/black/blob/master/docs/the_black_code_style.md