### PR TITLE
ReivewRate fixes

### DIFF
--- a/bookwyrm/migrations/0046_reviewrating.py
+++ b/bookwyrm/migrations/0046_reviewrating.py
@@ -4,6 +4,7 @@ from django.db import migrations, models
 from django.db import connection
 from django.db.models import Q
 import django.db.models.deletion
+from psycopg2.extras import execute_values
 
 def convert_review_rating(app_registry, schema_editor):
     ''' take rating type Reviews and convert them to ReviewRatings '''
@@ -16,11 +17,10 @@ def convert_review_rating(app_registry, schema_editor):
     )
 
     with connection.cursor() as cursor:
-        for review in reviews:
-            cursor.execute('''
+        values = [(r.id,) for r in reviews]
+        execute_values(cursor, '''
 INSERT INTO bookwyrm_reviewrating(review_ptr_id)
-SELECT status_ptr_id FROM bookwyrm_review
-WHERE status_ptr_id=%s''', (review.id))
+VALUES %s''', values)
 
 def unconvert_review_rating(app_registry, schema_editor):
     ''' undo the conversion from ratings back to reviews'''

--- a/bookwyrm/migrations/0046_reviewrating.py
+++ b/bookwyrm/migrations/0046_reviewrating.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 import django.db.models.deletion
 
 def convert_review_rating(app_registry, schema_editor):
-    ''' take rating type Reviews and conver them to ReviewRatings '''
+    ''' take rating type Reviews and convert them to ReviewRatings '''
     db_alias = schema_editor.connection.alias
 
     reviews = app_registry.get_model(
@@ -20,23 +20,13 @@ def convert_review_rating(app_registry, schema_editor):
             cursor.execute('''
 INSERT INTO bookwyrm_reviewrating(review_ptr_id)
 SELECT status_ptr_id FROM bookwyrm_review
-WHERE status_ptr_id={:d}'''.format(review.id))
+WHERE status_ptr_id=%s''', (review.id))
 
 def unconvert_review_rating(app_registry, schema_editor):
     ''' undo the conversion from ratings back to reviews'''
-    # TODO: this does not work
-    db_alias = schema_editor.connection.alias
-
-    ratings = app_registry.get_model(
-        'bookwyrm', 'ReviewRating'
-    ).objects.using(db_alias).all()
-
-    with connection.cursor() as cursor:
-        for rating in ratings:
-            cursor.execute('''
-INSERT INTO bookwyrm_review(status_ptr_id)
-SELECT review_ptr_id FROM bookwyrm_reviewrating
-WHERE review_ptr_id={:d}'''.format(rating.id))
+    # All we need to do to revert this is drop the table, which Django will do
+    # on its own, as long as we have a valid reverse function. So, this is a
+    # no-op function so Django will do its thing
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
PRs into PRs! What a world

This makes the downward migration work in the silliest way, which is...just doing nothing, so that Django will drop the table, which accomplishes what we want. Sheesh!

Also I dig the new string formatting, but I replaced it with SQL parameters, which are safer and the way to go when you're messing with direct queries.

I also added second commit with some even more SQL-y code, to insert all the values at once, that you can take or leave. I tried to do it the way I advised in the original PR and ran into probably the same thing you did, which is that the `content` column is actually on some other parent model's table, which could be worked around with JOINs, but I decided I didn't want to mess with that, but did the next best thing, which is using the query we already had, gathering all the ids we want together, and inserting them with one big `INSERT INTO...VALUES` statement. I even found a fancy psycopg helper that makes it nicer to work with VALUES lists, whee!

I tested these and made sure they got the same results as the original code (and reversed cleanly) by dumping the database before migrating, after migrating up, and after migrating back down, and all looked as expected.