### PR TITLE
Reduce Dockerfile size and the number of RUN steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,12 @@ FROM python:3.9
 
 ENV PYTHONUNBUFFERED 1
 
-RUN mkdir /app
-RUN mkdir /app/static
-RUN mkdir /app/images
+RUN mkdir /app /app/static /app/images
 
 WORKDIR /app
 
 COPY requirements.txt /app/
-RUN pip install -r requirements.txt
-RUN apt-get update && apt-get install -y gettext libgettextpo-dev
+RUN pip install -r requirements.txt --no-cache-dir
+RUN apt-get update && apt-get install -y gettext libgettextpo-dev && apt-get clean
 
-COPY ./bookwyrm /app
-COPY ./celerywyrm /app
+COPY ./bookwyrm ./celerywyrm /app/


### PR DESCRIPTION
I've modified the Dockerfile when experimenting with creating a standalone Bookwyrm-only set of images.

This reduces the image size by about 80 MB.