### PR TITLE
Screen reader improvements

### DIFF
--- a/bookwyrm/templates/feed/feed.html
+++ b/bookwyrm/templates/feed/feed.html
@@ -6,13 +6,13 @@
 <h1 class="title">{% blocktrans %}{{ tab_title }} Timeline{% endblocktrans %}</h1>
 <div class="tabs">
     <ul>
-        <li class="{% if tab == 'home' %}is-active{% endif %}">
+        <li class="{% if tab == 'home' %}is-active{% endif %}"{% if tab == 'home' %} aria-current="page"{% endif %}>
             <a href="/#feed">{% trans "Home" %}</a>
         </li>
-        <li class="{% if tab == 'local' %}is-active{% endif %}">
+        <li class="{% if tab == 'local' %}is-active{% endif %}"{% if tab == 'local' %} aria-current="page"{% endif %}>
             <a href="/local#feed">{% trans "Local" %}</a>
         </li>
-        <li class="{% if tab == 'federated' %}is-active{% endif %}">
+        <li class="{% if tab == 'federated' %}is-active{% endif %}"{% if tab == 'federated' %} aria-current="page"{% endif %}>
             <a href="/federated#feed">{% trans "Federated" %}</a>
         </li>
     </ul>

--- a/bookwyrm/templates/feed/status.html
+++ b/bookwyrm/templates/feed/status.html
@@ -4,7 +4,7 @@
 {% block panel %}
 <header class="block">
     <a href="/#feed" class="button" data-back>
-        <span class="icon icon-arrow-left" aira-hidden="true"></span>
+        <span class="icon icon-arrow-left" aria-hidden="true"></span>
         <span>{% trans "Back" %}</span>
     </a>
 </header>

--- a/bookwyrm/templates/snippets/avatar.html
+++ b/bookwyrm/templates/snippets/avatar.html
@@ -1,3 +1,3 @@
 {% load bookwyrm_tags %}
-<img class="avatar image {% if large %}is-96x96{% else %}is-32x32{% endif %}" src="{% if user.avatar %}/images/{{ user.avatar }}{% else %}/static/images/default_avi.jpg{% endif %}" alt="{{ user.alt_text }}">
+<img class="avatar image {% if large %}is-96x96{% else %}is-32x32{% endif %}" src="{% if user.avatar %}/images/{{ user.avatar }}{% else %}/static/images/default_avi.jpg{% endif %}" {% if ariaHide %}aria-hidden="true"{% endif %} alt="{{ user.alt_text }}">
 

--- a/bookwyrm/templates/snippets/status/status_header.html
+++ b/bookwyrm/templates/snippets/status/status_header.html
@@ -1,6 +1,6 @@
 {% load bookwyrm_tags %}
 {% load i18n %}
-{% include 'snippets/avatar.html' with user=status.user %}
+{% include 'snippets/avatar.html' with user=status.user ariaHide="true" %}
 {% include 'snippets/username.html' with user=status.user %}
 
 {% if status.status_type == 'GeneratedNote' %}


### PR DESCRIPTION
I've added some improvements for screen reader users:

* The currently active page is now indicated on the home/local/federated status pages for their respective links.
* The avatar image is now completely hidden on status pages. There is a link for the user whose status is displayed, so in this case the image does not serve a purpose to screen reader users and it was quite chatty while navigating through headings.
* I've also noticed a small typo, which I fixed.

Hopefully my non-existent Django templating knowledge is not a problem ☺️. This should not break anything visually, but please let me know if it does.