### PR TITLE
Federation errors

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -102,7 +102,7 @@ class ActivityObject:
         if allow_create and \
                 hasattr(model, 'ignore_activity') and \
                 model.ignore_activity(self):
-            return None
+            raise ActivitySerializerError()
 
         # check for an existing instance
         instance = instance or model.find_existing(self.serialize())

--- a/bookwyrm/models/activitypub_mixin.py
+++ b/bookwyrm/models/activitypub_mixin.py
@@ -449,7 +449,7 @@ def broadcast_task(sender_id, activity, recipients):
     for recipient in recipients:
         try:
             sign_and_send(sender, activity, recipient)
-        except (HTTPError, SSLError) as e:
+        except (HTTPError, SSLError, ConnectionError) as e:
             logger.exception(e)
 
 

--- a/bookwyrm/models/book.py
+++ b/bookwyrm/models/book.py
@@ -37,6 +37,10 @@ class BookDataModel(ObjectMixin, BookWyrmModel):
             self.remote_id = None
         return super().save(*args, **kwargs)
 
+    def broadcast(self, activity, sender, software='bookwyrm'):
+        ''' only send book data updates to other bookwyrm instances '''
+        super().broadcast(activity, sender, software=software)
+
 
 class Book(BookDataModel):
     ''' a generic book, which can mean either an edition or a work '''

--- a/bookwyrm/models/favorite.py
+++ b/bookwyrm/models/favorite.py
@@ -7,6 +7,7 @@ from bookwyrm import activitypub
 from .activitypub_mixin import ActivityMixin
 from .base_model import BookWyrmModel
 from . import fields
+from .status import Status
 
 class Favorite(ActivityMixin, BookWyrmModel):
     ''' fav'ing a post '''
@@ -20,7 +21,7 @@ class Favorite(ActivityMixin, BookWyrmModel):
     @classmethod
     def ignore_activity(cls, activity):
         ''' don't bother with incoming favs of unknown statuses '''
-        return not cls.objects.filter(remote_id=activity.object).exists()
+        return not Status.objects.filter(remote_id=activity.object).exists()
 
     def save(self, *args, **kwargs):
         ''' update user active time '''

--- a/bookwyrm/models/favorite.py
+++ b/bookwyrm/models/favorite.py
@@ -17,6 +17,11 @@ class Favorite(ActivityMixin, BookWyrmModel):
 
     activity_serializer = activitypub.Like
 
+    @classmethod
+    def ignore_activity(cls, activity):
+        ''' don't bother with incoming favs of unknown statuses '''
+        return cls.objects.filter(remote_id=activity.object).exists()
+
     def save(self, *args, **kwargs):
         ''' update user active time '''
         self.user.last_active_date = timezone.now()

--- a/bookwyrm/models/favorite.py
+++ b/bookwyrm/models/favorite.py
@@ -20,7 +20,7 @@ class Favorite(ActivityMixin, BookWyrmModel):
     @classmethod
     def ignore_activity(cls, activity):
         ''' don't bother with incoming favs of unknown statuses '''
-        return cls.objects.filter(remote_id=activity.object).exists()
+        return not cls.objects.filter(remote_id=activity.object).exists()
 
     def save(self, *args, **kwargs):
         ''' update user active time '''

--- a/bookwyrm/tests/activitypub/test_base_activity.py
+++ b/bookwyrm/tests/activitypub/test_base_activity.py
@@ -208,7 +208,10 @@ class BaseActivity(TestCase):
         # sets the celery task call to the function call
         with patch(
                 'bookwyrm.activitypub.base_activity.set_related_field.delay'):
-            update_data.to_model(model=models.Status, instance=status)
+            with patch('bookwyrm.models.status.Status.ignore_activity') \
+                    as discarder:
+                discarder.return_value = False
+                update_data.to_model(model=models.Status, instance=status)
         self.assertIsNone(status.attachments.first())
 
 

--- a/bookwyrm/tests/views/test_inbox.py
+++ b/bookwyrm/tests/views/test_inbox.py
@@ -484,7 +484,7 @@ class Inbox(TestCase):
             'actor': 'https://example.com/users/rat',
             'type': 'Like',
             'published': 'Mon, 25 May 2020 19:31:20 GMT',
-            'object': 'https://example.com/status/1',
+            'object': self.status.remote_id,
         }
 
         views.inbox.activity_task(activity)

--- a/bookwyrm/tests/views/test_inbox.py
+++ b/bookwyrm/tests/views/test_inbox.py
@@ -74,7 +74,7 @@ class Inbox(TestCase):
             mock_valid.return_value = False
             result = self.client.post(
                 '/user/mouse/inbox',
-                '{"type": "Test", "object": "exists"}',
+                '{"type": "Announce", "object": "exists"}',
                 content_type="application/json"
             )
             self.assertEqual(result.status_code, 401)
@@ -493,6 +493,21 @@ class Inbox(TestCase):
         self.assertEqual(fav.status, self.status)
         self.assertEqual(fav.remote_id, 'https://example.com/fav/1')
         self.assertEqual(fav.user, self.remote_user)
+
+    def test_ignore_favorite(self):
+        ''' don't try to save an unknown status '''
+        activity = {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            'id': 'https://example.com/fav/1',
+            'actor': 'https://example.com/users/rat',
+            'type': 'Like',
+            'published': 'Mon, 25 May 2020 19:31:20 GMT',
+            'object': 'https://unknown.status/not-found',
+        }
+
+        views.inbox.activity_task(activity)
+
+        self.assertFalse(models.Favorite.objects.exists())
 
     def test_handle_unfavorite(self):
         ''' fav a status '''


### PR DESCRIPTION
This will fix a few errors that commonly show up in celery tasks related to federation:
- Likes of unknown statuses always cause errors
- Broadcasting has all kinds of ways to fail to connect to remote servers
- Trying to broadcast book data updates to non-bookwyrm servers is pointless
- Checking signature validity for activities that are malformed