### PR TITLE
Ignore activities that expect dict args but get strs

### DIFF
--- a/bookwyrm/activitypub/verbs.py
+++ b/bookwyrm/activitypub/verbs.py
@@ -64,6 +64,11 @@ class Undo(Verb):
 
     def action(self):
         """ find and remove the activity object """
+        if isinstance(self.object, str):
+            # it may be that sometihng should be done with these, but idk what
+            # this seems just to be coming from pleroma
+            return
+
         # this is so hacky but it does make it work....
         # (because you Reject a request and Undo a follow
         model = None


### PR DESCRIPTION
Some Undo activities are coming from Pleroma with just the id
of the activity, rather than the serialized object. There isn't
an obvious way to know what is being undone, so for now this
just ignores those