### PR TITLE
Soft removal of tags feature

### DIFF
--- a/bookwyrm/templates/book/book.html
+++ b/bookwyrm/templates/book/book.html
@@ -165,32 +165,11 @@
                 {% include 'snippets/readthrough.html' with readthrough=readthrough %}
                 {% endfor %}
             </section>
-            {% endif %}
 
-            {% if request.user.is_authenticated %}
             <section class="box">
                 {% include 'snippets/create_status.html' with book=book hide_cover=True %}
             </section>
-
-            <section class="block">
-                <form name="tag" action="/tag/" method="post">
-                    <label for="tags" class="is-3">{% trans "Tags" %}</label>
-                    {% csrf_token %}
-                    <input type="hidden" name="book" value="{{ book.id }}">
-                    <input id="tags" class="input" type="text" name="name">
-                    <button class="button" type="submit">{% trans "Add tag" %}</button>
-                </form>
-            </section>
             {% endif %}
-
-            <div class="block">
-                <div class="field is-grouped is-grouped-multiline">
-                {% for tag in tags %}
-                    {% include 'snippets/tag.html' with book=book tag=tag user_tags=user_tags %}
-                {% endfor %}
-                </div>
-            </div>
-
         </div>
         <div class="column is-one-fifth">
             {% if book.subjects %}


### PR DESCRIPTION
I don't use tags, hardly anyone has ever used tags, and it's kinda janky! Plus, I need to add # tags in the mastodon sense, and that's going to be super confusing. This just removes the UI for tags. If anyone objects strongly, we can talk further. If not, the rest of the related code can be pulled out.