### PR TITLE
Show disabled placeholders in pagination

### DIFF
--- a/bookwyrm/templates/snippets/pagination.html
+++ b/bookwyrm/templates/snippets/pagination.html
@@ -1,20 +1,12 @@
 {% load i18n %}
 <nav class="pagination" aria-label="pagination">
-    {% if page.has_previous %}
-    <p class="pagination-previous">
-    <a href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.previous_page_number }}{{ anchor }}">
-            <span class="icon icon-arrow-left"></span>
-            {% trans "Previous" %}
-        </a>
-    </p>
-    {% endif %}
+    <a class="pagination-previous" {% if page.has_previous %}href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.previous_page_number }}{{ anchor }}" {% else %}disabled{% endif %}>
+        <span class="icon icon-arrow-left"></span>
+        {% trans "Previous" %}
+    </a>
 
-    {% if page.has_next %}
-    <p class="pagination-next">
-    <a href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.next_page_number }}{{ anchor }}">
-            {% trans "Next" %}
-            <span class="icon icon-arrow-right"></span>
-        </a>
-    </p>
-    {% endif %}
+    <a class="pagination-next" {% if page.has_next %}href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.next_page_number }}{{ anchor }}"{% else %} disabled{% endif %}>
+        {% trans "Next" %}
+        <span class="icon icon-arrow-right"></span>
+    </a>
 </nav>


### PR DESCRIPTION
This way the "next" button doesn't jump from the left side of the page to the right