### PR TITLE
Valid html solution to disabling pagination links

### DIFF
--- a/bookwyrm/static/css/format.css
+++ b/bookwyrm/static/css/format.css
@@ -25,14 +25,13 @@ html {
     min-width: 75% !important;
 }
 
-
 /* --- "disabled" for non-buttons --- */
 .is-disabled {
     background-color: #dbdbdb;
     border-color: #dbdbdb;
     box-shadow: none;
     color: #7a7a7a;
-    opacity: .5;
+    opacity: 0.5;
     cursor: not-allowed;
 }
 

--- a/bookwyrm/static/css/format.css
+++ b/bookwyrm/static/css/format.css
@@ -25,6 +25,17 @@ html {
     min-width: 75% !important;
 }
 
+
+/* --- "disabled" for non-buttons --- */
+.is-disabled {
+    background-color: #dbdbdb;
+    border-color: #dbdbdb;
+    box-shadow: none;
+    color: #7a7a7a;
+    opacity: .5;
+    cursor: not-allowed;
+}
+
 /* --- SHELVING --- */
 
 /** @todo Replace icons with SVG symbols.

--- a/bookwyrm/templates/snippets/pagination.html
+++ b/bookwyrm/templates/snippets/pagination.html
@@ -1,12 +1,26 @@
 {% load i18n %}
 <nav class="pagination" aria-label="pagination">
-    <a class="pagination-previous {% if not page.has_previous %}is-disabled{% endif %}" {% if page.has_previous %}href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.previous_page_number }}{{ anchor }}"{% endif %}>
-        <span class="icon icon-arrow-left"></span>
+    <a
+        class="pagination-previous {% if not page.has_previous %}is-disabled{% endif %}"
+        {% if page.has_previous %}
+        href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.previous_page_number }}{{ anchor }}"
+        {% else %}
+        aria-hidden="true"
+        {% endif %}>
+
+        <span class="icon icon-arrow-left" aria-hidden="true"></span>
         {% trans "Previous" %}
     </a>
 
-    <a class="pagination-next {% if not page.has_next %}is-disabled{% endif %}" {% if page.has_next %}href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.next_page_number }}{{ anchor }}"{% endif %}>
+    <a
+        class="pagination-next {% if not page.has_next %}is-disabled{% endif %}"
+        {% if page.has_next %}
+        href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.next_page_number }}{{ anchor }}"
+        {% else %}
+        aria-hidden="true"
+        {% endif %}>
+
         {% trans "Next" %}
-        <span class="icon icon-arrow-right"></span>
+        <span class="icon icon-arrow-right" aria-hidden="true"></span>
     </a>
 </nav>

--- a/bookwyrm/templates/snippets/pagination.html
+++ b/bookwyrm/templates/snippets/pagination.html
@@ -1,11 +1,11 @@
 {% load i18n %}
 <nav class="pagination" aria-label="pagination">
-    <a class="pagination-previous" {% if page.has_previous %}href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.previous_page_number }}{{ anchor }}" {% else %}disabled{% endif %}>
+    <a class="pagination-previous {% if not page.has_previous %}is-disabled{% endif %}" {% if page.has_previous %}href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.previous_page_number }}{{ anchor }}"{% endif %}>
         <span class="icon icon-arrow-left"></span>
         {% trans "Previous" %}
     </a>
 
-    <a class="pagination-next" {% if page.has_next %}href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.next_page_number }}{{ anchor }}"{% else %} disabled{% endif %}>
+    <a class="pagination-next {% if not page.has_next %}is-disabled{% endif %}" {% if page.has_next %}href="{{ path }}?{% for k, v in request.GET.items %}{% if k != 'page' %}{{ k }}={{ v }}&{% endif %}{% endfor %}page={{ page.next_page_number }}{{ anchor }}"{% endif %}>
         {% trans "Next" %}
         <span class="icon icon-arrow-right"></span>
     </a>


### PR DESCRIPTION
Uses a class to disable pagination links, rather than the `disabled` attribute (cc @arkhi )

In my screenreader (mac OSX VoiceOver), a disabled pagination link reads as plain text, and an active link reads as a link, which seems fine to me.