### PR TITLE
772 Use gettext_lazy for form classes

### DIFF
--- a/bookwyrm/forms.py
+++ b/bookwyrm/forms.py
@@ -6,7 +6,7 @@ from django import forms
 from django.forms import ModelForm, PasswordInput, widgets
 from django.forms.widgets import Textarea
 from django.utils import timezone
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from bookwyrm import models
 


### PR DESCRIPTION
https://github.com/mouse-reeve/bookwyrm/issues/772

`gettext` at import time will be static, so use `gettext_lazy` instead. 