### PR TITLE
Fixes boosted remote statuses coming in as Statuses instead of Review/Comment/etc

### DIFF
--- a/bookwyrm/activitypub/base_activity.py
+++ b/bookwyrm/activitypub/base_activity.py
@@ -265,7 +265,8 @@ def resolve_remote_id(
             "Could not connect to host for remote_id in: %s" % (remote_id)
         )
     # determine the model implicitly, if not provided
-    if not model:
+    # or if it's a model with subclasses like Status, check again
+    if not model or hasattr(model.objects, "select_subclasses"):
         model = get_model_from_type(data.get("type"))
 
     # check for existing items with shared unique identifiers

--- a/bookwyrm/tests/views/test_inbox.py
+++ b/bookwyrm/tests/views/test_inbox.py
@@ -608,8 +608,8 @@ class Inbox(TestCase):
                 "summary": "",
                 "tag": [],
                 "sensitive": False,
-                "@context": "https://www.w3.org/ns/activitystreams"
-            }
+                "@context": "https://www.w3.org/ns/activitystreams",
+            },
         )
 
         with patch("bookwyrm.models.status.Status.ignore_activity") as discarder:


### PR DESCRIPTION
the problem wasn't the request getting the wrong data, it was that because the related model on the `boosted_states` foreign key field is `Status`, it was serializing the data as `Note` even though it had the right activity type.

Fixes #858 