### PR TITLE
fix the book edit confirmation template dropping initial data for dates

### DIFF
--- a/bookwyrm/templates/book/edit_book.html
+++ b/bookwyrm/templates/book/edit_book.html
@@ -124,7 +124,7 @@
 
                 <p class="mb-2">
                     <label class="label" for="id_first_published_date">{% trans "First published date:" %}</label>
-                    <input type="date" name="first_published_date" class="input" id="id_first_published_date"{% if book.first_published_date %} value="{{ book.first_published_date|date:'Y-m-d' }}"{% endif %}>
+                    <input type="date" name="first_published_date" class="input" id="id_first_published_date"{% if book.first_published_date %} value="{{ book.first_published_date|date:'Y-m-d' }}"{% elif form.first_published_date.value %} value="{{ form.first_published_date.value }}"{% endif %}>
                 </p>
                 {% for error in form.first_published_date.errors %}
                 <p class="help is-danger">{{ error | escape }}</p>
@@ -132,7 +132,7 @@
 
                 <p class="mb-2">
                     <label class="label" for="id_published_date">{% trans "Published date:" %}</label>
-                    <input type="date" name="published_date" class="input" id="id_published_date"{% if book.published_date %} value="{{ book.published_date|date:'Y-m-d' }}"{% endif %}>
+                    <input type="date" name="published_date" class="input" id="id_published_date"{% if book.published_date %} value="{{ book.published_date|date:'Y-m-d' }}"{% elif form.published_date.value %} value="{{ form.first_published_date.value }}"{% endif %}>
                 </p>
                 {% for error in form.published_date.errors %}
                 <p class="help is-danger">{{ error | escape }}</p>

--- a/bookwyrm/templates/book/edit_book.html
+++ b/bookwyrm/templates/book/edit_book.html
@@ -124,7 +124,7 @@
 
                 <p class="mb-2">
                     <label class="label" for="id_first_published_date">{% trans "First published date:" %}</label>
-                    <input type="date" name="first_published_date" class="input" id="id_first_published_date"{% if book.first_published_date %} value="{{ book.first_published_date|date:'Y-m-d' }}"{% elif form.first_published_date.value %} value="{{ form.first_published_date.value }}"{% endif %}>
+                    <input type="date" name="first_published_date" class="input" id="id_first_published_date"{% if form.first_published_date.value %} value="{{ form.first_published_date.value|date:'Y-m-d' }}"{% endif %}>
                 </p>
                 {% for error in form.first_published_date.errors %}
                 <p class="help is-danger">{{ error | escape }}</p>
@@ -132,7 +132,7 @@
 
                 <p class="mb-2">
                     <label class="label" for="id_published_date">{% trans "Published date:" %}</label>
-                    <input type="date" name="published_date" class="input" id="id_published_date"{% if book.published_date %} value="{{ book.published_date|date:'Y-m-d' }}"{% elif form.published_date.value %} value="{{ form.first_published_date.value }}"{% endif %}>
+                    <input type="date" name="published_date" class="input" id="id_published_date"{% if form.published_date.value %} value="{{ form.published_date.value|date:'Y-m-d'}}"{% endif %}>
                 </p>
                 {% for error in form.published_date.errors %}
                 <p class="help is-danger">{{ error | escape }}</p>

--- a/bookwyrm/views/books.py
+++ b/bookwyrm/views/books.py
@@ -176,8 +176,18 @@ class EditBook(View):
             # we have to make sure the dates are passed in as datetime, they're currently a string
             # QueryDicts are immutable, we need to copy
             formcopy = data["form"].data.copy()
-            formcopy["first_published_date"] = datetime.strptime(formcopy["first_published_date"], "%Y-%m-%d")
-            formcopy["published_date"] = datetime.strptime(formcopy["published_date"], "%Y-%m-%d")
+            try:
+                formcopy["first_published_date"] = datetime.strptime(
+                    formcopy["first_published_date"], "%Y-%m-%d"
+                )
+            except MultiValueDictKeyError:
+                pass
+            try:
+                formcopy["published_date"] = datetime.strptime(
+                    formcopy["published_date"], "%Y-%m-%d"
+                )
+            except MultiValueDictKeyError:
+                pass
             data["form"].data = formcopy
             return TemplateResponse(request, "book/edit_book.html", data)
 

--- a/bookwyrm/views/books.py
+++ b/bookwyrm/views/books.py
@@ -1,4 +1,5 @@
 """ the good stuff! the books! """
+from datetime import datetime
 from uuid import uuid4
 
 from django.contrib.auth.decorators import login_required, permission_required
@@ -172,6 +173,12 @@ class EditBook(View):
             data["confirm_mode"] = True
             # this isn't preserved because it isn't part of the form obj
             data["remove_authors"] = request.POST.getlist("remove_authors")
+            # we have to make sure the dates are passed in as datetime, they're currently a string
+            # QueryDicts are immutable, we need to copy
+            formcopy = data["form"].data.copy()
+            formcopy["first_published_date"] = datetime.strptime(formcopy["first_published_date"], "%Y-%m-%d")
+            formcopy["published_date"] = datetime.strptime(formcopy["published_date"], "%Y-%m-%d")
+            data["form"].data = formcopy
             return TemplateResponse(request, "book/edit_book.html", data)
 
         remove_authors = request.POST.getlist("remove_authors")

--- a/bookwyrm/views/books.py
+++ b/bookwyrm/views/books.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 from uuid import uuid4
 
+from dateutil.parser import parse as dateparse
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.postgres.search import SearchRank, SearchVector
 from django.core.files.base import ContentFile
@@ -178,15 +179,13 @@ class EditBook(View):
             # QueryDicts are immutable, we need to copy
             formcopy = data["form"].data.copy()
             try:
-                formcopy["first_published_date"] = datetime.strptime(
-                    formcopy["first_published_date"], "%Y-%m-%d"
+                formcopy["first_published_date"] = dateparse(
+                    formcopy["first_published_date"]
                 )
             except MultiValueDictKeyError:
                 pass
             try:
-                formcopy["published_date"] = datetime.strptime(
-                    formcopy["published_date"], "%Y-%m-%d"
-                )
+                formcopy["published_date"] = dateparse(formcopy["published_date"])
             except MultiValueDictKeyError:
                 pass
             data["form"].data = formcopy

--- a/bookwyrm/views/books.py
+++ b/bookwyrm/views/books.py
@@ -11,6 +11,7 @@ from django.db.models import Avg, Q
 from django.http import HttpResponseBadRequest, HttpResponseNotFound
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
+from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.decorators import method_decorator
 from django.views import View
 from django.views.decorators.http import require_POST


### PR DESCRIPTION
this is a terrible commit message, sorry xd

the template was checking for initial date values in `book`, but in the confirmation dialogue, it needs to look in `form`. it's kind of ugly, but i'm not sure there's a better way that doesn't also rework a lot of book editing view. making this a draft pr in case anyone has a suggestion though!

edit: whoops, meant to post the issue first. related: #894