### PR TITLE
Use run instead of exec for bw-dev web commands

### DIFF
--- a/bw-dev
+++ b/bw-dev
@@ -19,7 +19,6 @@ function clean {
 
 function runweb {
     docker-compose run --rm web "$@"
-    clean
 }
 
 function execdb {
@@ -64,17 +63,16 @@ case "$CMD" in
         clean
         ;;
     makemigrations)
-        execweb python manage.py makemigrations "$@"
+        runweb python manage.py makemigrations "$@"
         ;;
     migrate)
-        execweb python manage.py rename_app fedireads bookwyrm
-        execweb python manage.py migrate "$@"
+        runweb python manage.py migrate "$@"
         ;;
     bash)
-        execweb bash
+        runweb bash
         ;;
     shell)
-        execweb python manage.py shell
+        runweb python manage.py shell
         ;;
     dbshell)
         execdb psql -U ${POSTGRES_USER} ${POSTGRES_DB}
@@ -83,22 +81,19 @@ case "$CMD" in
         docker-compose restart celery_worker
         ;;
     test)
-        execweb coverage run --source='.' --omit="*/test*,celerywyrm*,bookwyrm/migrations/*" manage.py test "$@"
+        runweb coverage run --source='.' --omit="*/test*,celerywyrm*,bookwyrm/migrations/*" manage.py test "$@"
         ;;
     pytest)
-        execweb pytest --no-cov-on-fail "$@"
-        ;;
-    test_report)
-        execweb coverage report
+        runweb pytest --no-cov-on-fail "$@"
         ;;
     collectstatic)
-        execweb python manage.py collectstatic --no-input
+        runweb python manage.py collectstatic --no-input
         ;;
     makemessages)
-        execweb django-admin makemessages --no-wrap --ignore=venv3 $@
+        runweb django-admin makemessages --no-wrap --ignore=venv3 $@
         ;;
     compilemessages)
-        execweb django-admin compilemessages --ignore venv3 $@
+        runweb django-admin compilemessages --ignore venv3 $@
         ;;
     build)
         docker-compose build
@@ -110,7 +105,7 @@ case "$CMD" in
         makeitblack
         ;;
     populate_streams)
-        execweb python manage.py populate_streams
+        runweb python manage.py populate_streams
         ;;
     *)
         echo "Unrecognised command. Try: build, clean, up, initdb, resetdb, makemigrations, migrate, bash, shell, dbshell, restart_celery, test, pytest, test_report, black, populate_feeds"


### PR DESCRIPTION
The issue I had with this initially was the `clean` part, not the `run`
part