### PR TITLE
Ensure `EMAIL_USE_TLS` is read as a bool

### DIFF
--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -24,7 +24,7 @@ EMAIL_HOST = env("EMAIL_HOST")
 EMAIL_PORT = env("EMAIL_PORT", 587)
 EMAIL_HOST_USER = env("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD")
-EMAIL_USE_TLS = env("EMAIL_USE_TLS", True)
+EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS", True)
 DEFAULT_FROM_EMAIL = "admin@{:s}".format(env("DOMAIN"))
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)

--- a/celerywyrm/settings.py
+++ b/celerywyrm/settings.py
@@ -20,7 +20,7 @@ EMAIL_HOST = env("EMAIL_HOST")
 EMAIL_PORT = env("EMAIL_PORT")
 EMAIL_HOST_USER = env("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD")
-EMAIL_USE_TLS = env("EMAIL_USE_TLS")
+EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS")
 
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)


### PR DESCRIPTION
This change makes environs read `EMAIL_USE_TLS` as a bool, because otherwise it reads it as a string (so `"false"` ends up being True in boolean contexts, and TLS is always enabled)  