### PR TITLE
Use URL on Mastodon profiles in list of instances

### DIFF
--- a/instances.md
+++ b/instances.md
@@ -1,5 +1,5 @@
 
 | name | url | admin contact | open registration |
 | :--- | :-- | :------------ | :---------------- |
-| bookwyrm.social | http://bookwyrm.social/ | mousereeve@riseup.net / @tripofmice@friend.camp | ❌ |
-| wyrms.de | https://wyrms.de/ | wyrms@tofuwabo.hu / @tofuwabohu@subversive.zone | ❌ | 
+| bookwyrm.social | http://bookwyrm.social/ | mousereeve@riseup.net / [@tripofmice@friend.camp](https://friend.camp/@tripofmice) | ❌ |
+| wyrms.de | https://wyrms.de/ | wyrms@tofuwabo.hu / [@tofuwabohu@subversive.zone](https://subversive.zone/@tofuwabohu) | ❌ | 


### PR DESCRIPTION
The links to the Mastodon profiles currently default to `mailto:` when parsed by Markdown.