### PR TITLE
update links in README and {bookwyrm,celerywyrm}/settings.py files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Since the project is still in its early stages, the features are growing every d
 Web backend
 - [Django](https://www.djangoproject.com/) web server
 - [PostgreSQL](https://www.postgresql.org/) database
-- [ActivityPub](http://activitypub.rocks/) federation
-- [Celery](http://celeryproject.org/) task queuing
+- [ActivityPub](https://activitypub.rocks/) federation
+- [Celery](https://docs.celeryproject.org/) task queuing
 - [Redis](https://redis.io/) task backend
 - [Redis (again)](https://redis.io/) activity stream manager
 

--- a/bookwyrm/settings.py
+++ b/bookwyrm/settings.py
@@ -166,7 +166,7 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/2.0/howto/static-files/
+# https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 STATIC_URL = "/static/"

--- a/celerywyrm/settings.py
+++ b/celerywyrm/settings.py
@@ -149,7 +149,7 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/3.0/howto/static-files/
+# https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, env("STATIC_ROOT", "static"))


### PR DESCRIPTION
the link to celery's homepage has been dead for at least several months
activitypub.rocks now supports tls (yay!)
the links to django's docs were for older versions of django than what bookwyrm uses